### PR TITLE
don't upgrade pip, use default version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,8 @@ RUN pip install -q --no-cache-dir python-instagram==1.3.2 \
                    twitter-text==3.0 \
                    twitter==1.17.1 \
                    flask==0.12.3 \
-                   envoy==0.0.3
+                   envoy==0.0.3 \
+                   html5lib==1.0.1 
 
 RUN pip install -q --no-cache-dir charade
 RUN pip install -q --no-cache-dir boilerpipe3 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ RUN conda clean --all --yes --quiet
 
 # Pip install specific packages for MTSW3E
 RUN pip install --upgrade setuptools
-RUN pip install --upgrade pip
 RUN pip install -q --no-cache-dir python-instagram==1.3.2 \
                    python3-linkedin==1.0.1 \
                    PyGithub==1.35 \

--- a/notebooks/Chapter 6 - Mining Web Pages.ipynb
+++ b/notebooks/Chapter 6 - Mining Web Pages.ipynb
@@ -12,23 +12,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "# Downloading nltk packages used in this example\n",
-    "nltk.download('maxent_ne_chunker')\n",
-    "nltk.download('words')\n",
-    "\n",
-    "ne_chunks = list(nltk.chunk.ne_chunk_sents(pos_tagged_tokens))\n",
-    "print(ne_chunks)\n",
-    "ne_chunks[0].pprint()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -41,9 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# May also require the installation of Java runtime libraries\n",
@@ -70,9 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import feedparser # pip install feedparser\n",
@@ -97,9 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -143,9 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import httplib2\n",
@@ -204,9 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "text = \"Mr. Green killed Colonel Mustard in the study with the candlestick. Mr. Green is not a very nice fellow.\"\n",
@@ -223,9 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import nltk # Installation instructions: http://www.nltk.org/install.html\n",
@@ -237,9 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sentences = nltk.tokenize.sent_tokenize(text)\n",
@@ -249,9 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "harder_example = \"\"\"My name is John Smith and my email address is j.smith@company.com.\n",
@@ -272,9 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "text = \"Mr. Green killed Colonel Mustard in the study with the candlestick. Mr. Green is not a very nice fellow.\"\n",
@@ -294,9 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Downloading nltk packages used in this example\n",
@@ -364,9 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Downloading nltk packages used in this example\n",
@@ -377,9 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "jim = \"Jim bought 300 shares of Acme Corp. in 2006.\"\n",
@@ -393,9 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ne_chunks"
@@ -404,9 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ne_chunks = [nltk.chunk.ne_chunk(ptt) for ptt in pos_tagged_tokens]\n",
@@ -418,9 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ne_chunks[0]"
@@ -429,9 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ne_chunks[1]"
@@ -447,9 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
@@ -490,9 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for post in blog_data:\n",
@@ -537,9 +484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import json\n",
@@ -558,9 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "stop_words = nltk.corpus.stopwords.words('english') + [\n",
@@ -588,9 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Approach taken from \"The Automatic Creation of Literature Abstracts\" by H.P. Luhn\n",
@@ -654,9 +595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def summarize(txt):\n",
@@ -700,9 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for post in blog_data: \n",
@@ -731,9 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -789,9 +724,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import nltk\n",
@@ -860,9 +793,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import nltk\n",
@@ -929,9 +860,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
@@ -982,13 +911,20 @@
     "    print('Displaying {0}:'.format(f.name))\n",
     "    display(IFrame('files/{0}'.format(f.name), '100%', '600px'))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mtsw",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "mtsw"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1000,7 +936,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
upgrade pulled newest 19.0 version, which out of the box, without re-configuration, runs in to an error with --no-cache-dir:

*Exception:
Traceback (most recent call last):
  File "/opt/conda/lib/python3.6/site-packages/pip/_internal/cli/base_command.py", line 176, in main
    status = self.run(options, args)
  File "/opt/conda/lib/python3.6/site-packages/pip/_internal/commands/install.py", line 346, in run
    session=session, autobuilding=True
  File "/opt/conda/lib/python3.6/site-packages/pip/_internal/wheel.py", line 848, in build
    assert building_is_possible
AssertionError*
